### PR TITLE
[#37][feat] 카테고리를 통한 상품 조회 기능 구현

### DIFF
--- a/src/main/java/f4/product/domain/product/controller/ProductController.java
+++ b/src/main/java/f4/product/domain/product/controller/ProductController.java
@@ -6,7 +6,6 @@ import f4.product.domain.product.dto.response.AuctionTimeStatusDto;
 import f4.product.domain.product.dto.response.FeignProductDto;
 import f4.product.domain.product.dto.response.ProductReadResponseDto;
 import f4.product.domain.product.service.AuctionStatusService;
-import f4.product.domain.product.service.FavoriteService;
 import f4.product.domain.product.service.ProductService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -63,11 +61,18 @@ public class ProductController {
     return new ResponseEntity<>(products, HttpStatus.OK);
   }
 
-  @GetMapping("/search")
+  @GetMapping("/search/category")
   public ResponseEntity<List<ProductReadResponseDto>> findByMediumAndKeyword(
       @RequestParam String category, @RequestParam String keyword) {
     List<ProductReadResponseDto> products =
         productService.findByMediumAndKeyword(category, keyword);
+    return new ResponseEntity<>(products, HttpStatus.OK);
+  }
+
+  @GetMapping("/search")
+  public ResponseEntity<List<ProductReadResponseDto>> findByMedium(
+      @RequestParam String category) {
+    List<ProductReadResponseDto> products = productService.findByMedium(category);
     return new ResponseEntity<>(products, HttpStatus.OK);
   }
 

--- a/src/main/java/f4/product/domain/product/persist/repository/ProductRepository.java
+++ b/src/main/java/f4/product/domain/product/persist/repository/ProductRepository.java
@@ -21,9 +21,15 @@ public interface ProductRepository
 
   Optional<Product> findById(Long productId);
 
-  @Query(
-      "SELECT p FROM Product p WHERE p.theme = :medium AND (LOWER(p.style) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(p.technique) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+//  @Query("SELECT p FROM Product p WHERE p.theme = :medium AND (LOWER(p.style) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(p.technique) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+@Query("SELECT p FROM Product p WHERE p.medium = :medium " +
+    "AND (:keyword IS NULL OR " +
+    "LOWER(p.theme) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+    "LOWER(p.style) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+    "LOWER(p.technique) LIKE LOWER(CONCAT('%', :keyword, '%')))")
   Optional<List<Product>> findByMediumAndKeyword(String medium, String keyword);
+  @Query("SELECT p FROM Product p WHERE p.medium = :medium")
+  Optional<List<Product>> findByMedium(String medium);
 
   @Query("SELECT p FROM Product p WHERE p.auctionStatus = 'progress' AND p.auctionEndTime < ?1")
   List<Product> findCompletedAuctionsInProgress(LocalDateTime now);

--- a/src/main/java/f4/product/domain/product/service/ProductService.java
+++ b/src/main/java/f4/product/domain/product/service/ProductService.java
@@ -19,6 +19,7 @@ public interface ProductService {
   List<ProductReadResponseDto> findByArtist(String artist);
 
   List<ProductReadResponseDto> findByMediumAndKeyword(String theme, String keyword);
+  List<ProductReadResponseDto> findByMedium(String medium);
 
   void updateProduct(Long productId, ProductUpdateRequestDto updateDto);
 

--- a/src/main/java/f4/product/domain/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/f4/product/domain/product/service/impl/ProductServiceImpl.java
@@ -70,7 +70,9 @@ public class ProductServiceImpl implements ProductService {
   public List<ProductReadResponseDto> findByMediumAndKeyword(String medium, String keyword) {
     return findProductsOrThrow(productRepository.findByMediumAndKeyword(medium, keyword));
   }
-
+  public List<ProductReadResponseDto> findByMedium(String medium) {
+    return findProductsOrThrow(productRepository.findByMedium(medium));
+  }
   private void validateUniqueProductIdentifier(ProductSaveRequestDto requestDto) {
     String identifier = generateIdentifier(requestDto);
     if (productRepository.findByIdentifier(identifier).isPresent()) {


### PR DESCRIPTION
medium만을 기준으로 상품을 조회하는 API와 medium와 keyword를 함께 기준으로 조회 상품을 조회하는 API를 작성함.

repository : @Query를 사용하여 medium와 keyword를 기준으로 상품을 검색하는 쿼리와 findByMediumAndKeyword 메서드 작성함. 만약 keyword가 null이거나 없는 값일 때는 medium 조건만 걸리도록 작성함. @Query를 사용하여 medium만을 기준으로 상품을 검색하는 쿼리와  findByMedium 메서드 작성함.

Controller : 기존에 있던 medium와 keyword를 함께 기준으로 상품을 조회하는 메서드의 엔드포인트를 수정하고, medium만을 기준으로 상품을 조회하는 서비스 코드를 불러와 응답하는 컨트롤러 코드를 구현함.