### PR TITLE
[fix]단위 테스트 이후 변경사항 merge

### DIFF
--- a/src/main/java/f4/product/domain/product/controller/FavoriteController.java
+++ b/src/main/java/f4/product/domain/product/controller/FavoriteController.java
@@ -30,9 +30,7 @@ public class FavoriteController {
       @RequestHeader("userId") Long userId,
       @RequestParam("productId") Long productId) {
     log.info("관심상품 등록 요청 받음. 사용자 ID: {}, 상품 ID: {}", userId, productId);
-    favoriteService.saveFavorite(userId, productId);
-    ResponseEntity<?> response = favoriteService.saveFavorite(userId, productId);
-    return response;
+    return favoriteService.saveFavorite(userId, productId);
   }
 
   @GetMapping

--- a/src/main/java/f4/product/domain/product/service/feign/UserServiceAPI.java
+++ b/src/main/java/f4/product/domain/product/service/feign/UserServiceAPI.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 @FeignClient(name = "USER-SERVICE")
 public interface UserServiceAPI {
 
-  @GetMapping("/product/{userId}")
+  @GetMapping("/user/v1/product/{userId}")
   public ProductResponseDto existsByUserId(@PathVariable("userId") Long userId);
 
 }


### PR DESCRIPTION
userServiceAPI 엔드포인트 product/{userId}에서  /user/v1/product/{userId}로 수정함.

FavoriteController : 같은 상품에 중복 관심을 막기 위해 등록 시 userId와 productId가 같은 상품이 존재하면 관심을 삭제, 없다면 등록하는 saveFavorite API가 "등록되었습니다"라고만 응답하여 삭제 시 올바른 응답을 받게끔 수정